### PR TITLE
Use built in service env vars

### DIFF
--- a/bin/host-inventory-sync
+++ b/bin/host-inventory-sync
@@ -15,7 +15,7 @@ def parse_args
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int, :required => false, :default => (ENV["QUEUE_PORT"] || 9092).to_i
     opt :topological_inventory_api, "Topological Inventory service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?, :default => ENV["TOPOLOGICAL_INVENTORY_API"]
     opt :host_inventory_api, "Host inventory service URL", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?, :default => ENV["HOST_INVENTORY_API"]
-    opt :ingress_api, "Ingress API service URL", :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
+    opt :ingress_api, "Ingress API service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"].nil?
   end
 
   opts
@@ -23,7 +23,11 @@ end
 
 args = parse_args
 
-ingress_api_uri = URI(args[:ingress_api])
+ingress_api_uri = if args[:ingress_api]
+                    URI(args[:ingress_api])
+                  else
+                    URI::HTTP.build(:host => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"], :port => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"])
+                  end
 
 TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme || "http"
 TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"

--- a/bin/host-inventory-sync
+++ b/bin/host-inventory-sync
@@ -13,7 +13,7 @@ def parse_args
   opts = Optimist.options do
     opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string, :required => ENV["QUEUE_HOST"].nil?, :default => ENV["QUEUE_HOST"]
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int, :required => false, :default => (ENV["QUEUE_PORT"] || 9092).to_i
-    opt :topological_inventory_api, "Topological Inventory service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?, :default => ENV["TOPOLOGICAL_INVENTORY_API"]
+    opt :topological_inventory_api, "Topological Inventory service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"].nil?
     opt :host_inventory_api, "Host inventory service URL", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?, :default => ENV["HOST_INVENTORY_API"]
     opt :ingress_api, "Ingress API service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"].nil?
   end
@@ -26,6 +26,7 @@ args = parse_args
 ingress_api_uri = if args[:ingress_api]
                     URI(args[:ingress_api])
                   else
+                    require 'uri'
                     URI::HTTP.build(:host => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"], :port => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_PORT"])
                   end
 

--- a/bin/host-inventory-sync
+++ b/bin/host-inventory-sync
@@ -13,9 +13,9 @@ def parse_args
   opts = Optimist.options do
     opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string, :required => ENV["QUEUE_HOST"].nil?, :default => ENV["QUEUE_HOST"]
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int, :required => false, :default => (ENV["QUEUE_PORT"] || 9092).to_i
-    opt :topological_inventory_api, "Hostname of the Topological Inventory route", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?, :default => ENV["TOPOLOGICAL_INVENTORY_API"]
-    opt :host_inventory_api, "Hostname of the Host Inventory api route", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?, :default => ENV["HOST_INVENTORY_API"]
-    opt :ingress_api, "Hostname of the ingress-api route", :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
+    opt :topological_inventory_api, "Topological Inventory service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API"].nil?, :default => ENV["TOPOLOGICAL_INVENTORY_API"]
+    opt :host_inventory_api, "Host inventory service URL", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?, :default => ENV["HOST_INVENTORY_API"]
+    opt :ingress_api, "Ingress API service URL", :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
   end
 
   opts


### PR DESCRIPTION
Each service deployed in a namespace causes environment variables will information about that service to be exposed to the other running containers in the namespace.

Using these variables rather than passing in duplicate information about the other services will simplify the deployment of this app significantly.

