### PR TITLE
Use correct host-based inventory API URL

### DIFF
--- a/bin/host-inventory-sync
+++ b/bin/host-inventory-sync
@@ -14,7 +14,7 @@ def parse_args
     opt :queue_host, "Hostname of the Platform's kafka queue", :type => :string, :required => ENV["QUEUE_HOST"].nil?, :default => ENV["QUEUE_HOST"]
     opt :queue_port, "Port of the Platform's kafka queue", :type => :int, :required => false, :default => (ENV["QUEUE_PORT"] || 9092).to_i
     opt :topological_inventory_api, "Topological Inventory service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"].nil?
-    opt :host_inventory_api, "Host inventory service URL", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?, :default => ENV["HOST_INVENTORY_API"]
+    opt :host_inventory_api, "Host inventory service URL", :type => :string, :required => ENV["HOST_INVENTORY_API"].nil?
     opt :ingress_api, "Ingress API service URL", :type => :string, :required => ENV["TOPOLOGICAL_INVENTORY_INGRESS_API_SERVICE_HOST"].nil?
   end
 

--- a/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
+++ b/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
@@ -2,7 +2,6 @@ require "topological_inventory/host_inventory_sync"
 
 RSpec.describe TopologicalInventory::HostInventorySync do
   context "#topological_inventory_api (private)" do
-
     it "returns the initial url if provided" do
       expect(described_class.new("http://example.com/api/", "", "", 9092).send(:topological_inventory_api)).to eq("http://example.com/api/")
     end
@@ -10,14 +9,8 @@ RSpec.describe TopologicalInventory::HostInventorySync do
     context "with service env vars set" do
       let(:url) { described_class.new(nil, "", "", 9092).send(:topological_inventory_api) }
 
-      around do |e|
-        ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_HOST"] = "example.com"
-        ENV["TOPOLOGICAL_INVENTORY_API_SERVICE_PORT"] = "8080"
-
-        e.run
-
-        ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_HOST")
-        ENV.delete("TOPOLOGICAL_INVENTORY_API_SERVICE_PORT")
+      before do
+        stub_const("ENV", {"TOPOLOGICAL_INVENTORY_API_SERVICE_HOST" => "example.com", "TOPOLOGICAL_INVENTORY_API_SERVICE_PORT" => "8080"})
       end
 
       it "returns a sane value" do
@@ -25,12 +18,7 @@ RSpec.describe TopologicalInventory::HostInventorySync do
       end
 
       context "with APP_NAME set" do
-        around do |e|
-          ENV["APP_NAME"] = "topological-inventory"
-          e.run
-          ENV.delete("APP_NAME")
-          ENV.delete("PATH_PREFIX")
-        end
+        before { ENV["APP_NAME"] = "topological-inventory" }
 
         it "includes the APP_NAME" do
           expect(url).to eq("http://example.com:8080/topological-inventory/v0.1")

--- a/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
+++ b/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe TopologicalInventory::HostInventorySync do
     end
   end
 
+  context "#host_inventory_api (private)" do
+    it "returns the initial url if provided" do
+      expect(described_class.new("", "http://example.com/api/", "", 9092).send(:host_inventory_api)).to eq("http://example.com/api/")
+    end
+
+    context "with service env vars set" do
+      let(:url) { described_class.new("", nil, "", 9092).send(:host_inventory_api) }
+
+      before { stub_const("ENV", {"HOST_INVENTORY_API" => "http://example.com:8080"}) }
+
+      it "returns a sane value" do
+        expect(url).to eq("http://example.com:8080/inventory/api/v1")
+      end
+
+      it "uses the PATH_PREFIX with a leading slash" do
+        ENV["PATH_PREFIX"] = "/this/is/a/path"
+        expect(url).to eq("http://example.com:8080/this/is/a/path/inventory/api/v1")
+      end
+
+      it "uses the PATH_PREFIX without a leading slash" do
+        ENV["PATH_PREFIX"] = "also/a/path"
+        expect(url).to eq("http://example.com:8080/also/a/path/inventory/api/v1")
+      end
+    end
+  end
+
   context "#process_message" do
     let(:message) do
       OpenStruct.new(


### PR DESCRIPTION
Build the host-based inventory service url from the path prefix env var like we do for topological inventory.

We need separate url building logic here because the service environment variables are not provided to us in the same way and there is an extra `api` component in the path for host-based inventory.