### PR TITLE
Use metrics port from ENV variable if present

### DIFF
--- a/bin/host-inventory-sync
+++ b/bin/host-inventory-sync
@@ -39,7 +39,7 @@ def parse_args
         :default => ENV["APP_NAME"]
     opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics", :type => :integer,
         :required => false,
-        :default => 9394
+        :default => (ENV["METRICS_PORT"] || 9394).to_i
   end
 
   opts


### PR DESCRIPTION
[this is done in other places](https://github.com/ManageIQ/topological_inventory-amazon/blob/064b3f7a74d1fbdac7e5ae595abbc183a9d1dfde/bin/amazon-collector#L29)

@miq-bot assign @agrare 