### PR TITLE
Gems and API updates, Ingress API send fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,17 +3,18 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "activesupport", "~> 5.2.2"
+gem "activesupport", "~> 5.2.4", ">= 5.2.4.2"
 gem "cloudwatchlogger", "~> 0.2"
 gem "concurrent-ruby"
-gem "manageiq-loggers", "~> 0.3.0"
+gem "manageiq-loggers", "~> 0.4.0", ">= 0.4.2"
 gem "manageiq-messaging"
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rest-client", ">= 1.8.0"
 
-gem "topological_inventory-ingress_api-client", "~> 1.0"
+gem "topological_inventory-ingress_api-client", "~> 1.0.1"
+gem "topological_inventory-providers-common", "~> 0.1"
 
 group :development, :test do
   gem "rake"

--- a/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
+++ b/spec/topological_inventory/host_inventory_sync/host_inventory_sync_spec.rb
@@ -5,33 +5,33 @@ RSpec.describe TopologicalInventory::HostInventorySync do
     it "returns the initial url if provided" do
       params_hash = described_class.send(:build_topological_inventory_url_hash, "example.com", "9092", "", "")
       host_sync_object = described_class.new(params_hash, "", "", "", 0)
-      expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:9092/v1.0")
+      expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:9092/v3.0")
     end
 
     context "with service env vars set" do
       it "returns a sane value" do
         params_hash = described_class.send(:build_topological_inventory_url_hash, "example.com", "8080", "", "")
         host_sync_object = described_class.new(params_hash, "", "", "", 0)
-        expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/v1.0")
+        expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/v3.0")
       end
 
       context "with APP_NAME set" do
         it "includes the APP_NAME" do
           params_hash = described_class.send(:build_topological_inventory_url_hash, "example.com", "8080", "", "topological-inventory")
           host_sync_object = described_class.new(params_hash, "", "", "", 0)
-          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/topological-inventory/v1.0")
+          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/topological-inventory/v3.0")
         end
 
         it "uses the PATH_PREFIX with a leading slash" do
           params_hash = described_class.send(:build_topological_inventory_url_hash, "example.com", "8080", "/this/is/a/path", "topological-inventory")
           host_sync_object = described_class.new(params_hash, "", "", "", 0)
-          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/this/is/a/path/topological-inventory/v1.0")
+          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/this/is/a/path/topological-inventory/v3.0")
         end
 
         it "uses the PATH_PREFIX without a leading slash" do
           params_hash = described_class.send(:build_topological_inventory_url_hash, "example.com", "8080", "also/a/path", "topological-inventory")
           host_sync_object = described_class.new(params_hash, "", "", "", 0)
-          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/also/a/path/topological-inventory/v1.0")
+          expect(host_sync_object.send(:build_topological_inventory_url_from, {})).to eq("http://example.com:8080/also/a/path/topological-inventory/v3.0")
         end
       end
     end


### PR DESCRIPTION
- Updating deprecated gems
- Changing Topological API to v3.0
- adding `TopologicalInventory::Providers::Common::SaveInventory::Saver` - current code is not compatible